### PR TITLE
Fix unicode escapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,14 +211,15 @@ There are also surrogate code points, private and unassigned codepoints, and con
 ## Source Code
 |Encoding Type| Raw Encoding|
 |-------------|-------------|
-| JavaScript  | \u1F596 	|
-| JSON 	 	  | \u1F596 	|
+| JavaScript  | \uD83D\uDD96	|
+| JSON 	 	  | \uD83D\uDD96	|
 | C 		  | \u1F596 	|
 | C++ 		  | \u1F596 	|
-| Java		  | \u1F596		|
-| Python	  | \u1F596 	|
+| Java		  | \uD83D\uDD96	|
+| Python	  | \U0001F596 	|
 | Perl		  | \x{1F596}	|
 | Ruby		  | \u{1F596}	|
+| Rust		  | \u{1F596}	|
 | CSS		  | \01F596 	|
 
 


### PR DESCRIPTION
* Added Rust
* Python's `\u` only takes 4 hex digits, `\U` takes 8 (and can thus encode astral characters)
* Javascript, JSON and Java `\u` escape only takes 4 hex digits, for astral characters the surrogate pairs must be provided explicitly

The Python, JS, JSON and Java snippets encoded U+1F59 {GREEK CAPITAL LETTER UPSILON WITH DASIA} followed by U+0036 {DIGIT SIX} rather than U+1F596 {RAISED HAND WITH PART BETWEEN MIDDLE AND RING FINGERS}.

It is possible that other languages have the same issue. According to [CPPReference](http://en.cppreference.com/w/cpp/language/escape), C++ unicode escapes work the same way Python's do, and the C11 draft I have (ISO/IEC 9899:201x — April 12, 2011 § 6.4.3) specifies essentially the same thing: `\u` is followed by 4 hex digits, `\U` is followed by 8:

> ## 6.4.3 Universal character names
> ### Syntax
> universal-character-name:
>> \u hex-quad
>>  \U hex-quad hex-quad

> hex-quad:
>> hexadecimal-digit hexadecimal-digit hexadecimal-digit hexadecimal-digit
