### PR TITLE
fix image rendering issue in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,9 +745,10 @@ And heres some basic results
 # Overview Map
 ## A map of the Basic Multilingual Plane
 **Each numbered box represents 256 code points.**
-<center>
-![A map of the Basic Multilingual Plane. Each numbered box represents 256 code points.](https://upload.wikimedia.org/wikipedia/commons/thumb/8/8e/Roadmap_to_Unicode_BMP.svg/750px-Roadmap_to_Unicode_BMP.svg.png)
-</center>
+<p align="center">
+  <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8e/Roadmap_to_Unicode_BMP.svg/750px-Roadmap_to_Unicode_BMP.svg.png" alt="A map of the Basic Multilingual Plane. Each numbered box represents 256 code points."/>
+</p>
+
 *The Chinese, Japanese and Korean (CJK) scripts share a common background, collectively known as CJK characters. In the process called Han unification, the common (shared) characters were identified and named "CJK Unified Ideographs".*
 
 


### PR DESCRIPTION
image `A map of the Basic Multilingual Plane. Each numbered box represents 256 code points.` under [Overview Map] not being rendered correctly on github (at least on my chrome browsers on Linux and OSX) - although the rendering works fine on atom with markdown preview. Fixed with inline css.