### PR TITLE
Removing broken <center> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,9 +231,7 @@ There are also surrogate code points, private and unassigned codepoints, and con
 
 
 
-<center>
 [![](http://imgs.xkcd.com/comics/rtl.png )](https://xkcd.com/1137/)
-</center>
 
 ## Special Characters
 


### PR DESCRIPTION
Github Markdown doesn't want to render any Markdown inside of the `<center>` tag.

This fixes the broken Markdown showing up instead of the image below the [Awesome Characters List heading](https://github.com/jagracey/Awesome-Unicode#awesome-characters-list).